### PR TITLE
Make possible for customers to use 3.x or 4.x series of analytics-ios with Tapstream

### DIFF
--- a/Tapstream-Segment.podspec
+++ b/Tapstream-Segment.podspec
@@ -20,6 +20,6 @@ Pod::Spec.new do |s|
     'Tapstream-Segment' => ['Tapstream-Segment/Assets/*.png']
   }
 
-  s.dependency 'Analytics', '~> 3.0.0'
+  s.dependency 'Analytics'
   s.dependency 'Tapstream', '~> 2.11.0'
 end

--- a/Tapstream-Segment.podspec
+++ b/Tapstream-Segment.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "Tapstream-Segment"
-  s.version          = "1.0.0"
+  s.version          = "1.0.1"
   s.summary          = "Tapstream Integration for Segment's analytics-ios library."
 
   s.description      = <<-DESC


### PR DESCRIPTION
We're in the process of moving to the 4.x series of Analytics-iOS.  To allow Tapstream to continue to work, I've submitted a PR that removes version pinning.  Destinations will continue to work as they always have in 4.x series.